### PR TITLE
Map shown light/dark mode (CSS)

### DIFF
--- a/client/src/DarkMap.js
+++ b/client/src/DarkMap.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Blank_USA_Map from './Blank_USA_Map.png' // imports USA Map with state cross lines
+
+function DarkMap() {
+      
+    return (
+        <div>
+            <h2>USA Map</h2>
+            <img src={Blank_USA_Map} alt="USA Map" style={{ filter: 'invert(100%) grayscale(100%)' }} />
+        </div>
+    );
+}
+
+export default DarkMap;


### PR DESCRIPTION
having not only clear white map with gray shaded states, but we also have all black/dark map with white lines to represent the states. Only issue with it currently is the dots to show, but we can get to that later as it'll still go for the original map.